### PR TITLE
Remove redundant `when :timestamp` clause

### DIFF
--- a/lib/arrow-activerecord/arrowable.rb
+++ b/lib/arrow-activerecord/arrowable.rb
@@ -68,8 +68,6 @@ module ArrowActiveRecord
         Arrow::StringDataType.new
       when :time, :timestamp
         Arrow::TimestampDataType.new(:nano)
-      when :timestamp
-        Arrow::TimestampDataType.new(:nano)
       else
         message = "unsupported data type: #{type}: #{column.inspect}"
         raise NotImplementedError, message


### PR DESCRIPTION
This pull request removes redundant `when :timestamp` clause to address `warning: duplicated when clause is ignored`

```ruby
/path/to/red-arrow-activerecord/lib/arrow-activerecord/arrowable.rb:71: warning: duplicated when clause is ignored
```

#### Steps to reproduce:

```ruby
$ bundle exec rake test
/home/yahonda/.rbenv/versions/2.5.1/bin/ruby test/run-test.rb
/home/yahonda/git/red-arrow-activerecord/lib/arrow-activerecord/arrowable.rb:71: warning: duplicated when clause is ignored
Loaded suite test
Started
.
Finished in 0.046235516 seconds.
-------------------------------------------------------------------------------------------------------------------------------------
1 tests, 1 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-------------------------------------------------------------------------------------------------------------------------------------
21.63 tests/s, 21.63 assertions/s
```